### PR TITLE
Allow /dev/stdin to be used as a file input

### DIFF
--- a/kokoro-tts
+++ b/kokoro-tts
@@ -924,7 +924,7 @@ if __name__ == "__main__":
 
     # Ensure the input file exists
     if not os.access(input_file, os.R_OK):
-        print(f"Error: The file {input_file} does not exist.")
+        print(f"Error: Cannot read from {input_file}. File may not exist or you may not have permission to read it.")
         sys.exit(1)
     
     # Ensure the output file has a proper extension if specified

--- a/kokoro-tts
+++ b/kokoro-tts
@@ -923,7 +923,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     # Ensure the input file exists
-    if not os.path.isfile(input_file):
+    if not os.access(input_file, os.R_OK):
         print(f"Error: The file {input_file} does not exist.")
         sys.exit(1)
     


### PR DESCRIPTION
This is mainly for piping the input to avoid creating unnecessary files. For instance,
```sh
echo "I'm reading something that's not stored on a file" | ./kokoro-tts /dev/stdin output.wav
```

I also want it for piping on-the-fly llm outputs to this tool.