### PR TITLE
fix: Replace deprecated fitz API

### DIFF
--- a/kokoro_tts/__init__.py
+++ b/kokoro_tts/__init__.py
@@ -21,7 +21,7 @@ import soundfile as sf
 import sounddevice as sd
 from kokoro_onnx import Kokoro
 import pymupdf4llm
-import fitz
+import pymupdf
 
 warnings.filterwarnings("ignore", category=UserWarning, module='ebooklib')
 warnings.filterwarnings("ignore", category=FutureWarning, module='ebooklib')
@@ -534,7 +534,7 @@ class PdfParser:
         """
         doc = None
         try:
-            doc = fitz.open(self.pdf_path)
+            doc = pymupdf.open(self.pdf_path)
             toc = doc.get_toc()
             
             if not toc:
@@ -1399,4 +1399,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
 ## Description

  Replace the deprecated `fitz` compatibility import with the supported
  `pymupdf` module name and use that namespace when opening PDF files.

  This removes the following warning:

  > The fitz API is deprecated and will be removed in future. Use import pymupdf instead.

  ## Related Issue

  N/A — no issue was filed for this warning.

  ## Type of Change

  - [x] Bug fix (non-breaking change addressing an issue)
  - [ ] New feature (non-breaking change adding functionality)
  - [ ] Breaking change (fix or feature causing existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Other (please describe):

  ## Checklist

  - [x] I created a feature branch for this change
  - [x] My code follows the project's coding style
  - [x] I have tested my changes thoroughly
  - [x] No documentation changes are required
  - [x] My commit follows the commit message guidelines
  - [ ] I have added automated tests (the repository currently has no test suite)
  - [x] Existing verification checks pass with my changes

  ## Screenshots

  Not applicable.

  ## Additional Context

  Validation performed:

  - Compiled `kokoro_tts/__init__.py` and `kokoro_tts/__main__.py`
  - Created, saved, and reopened a one-page PDF using `pymupdf`
  - Confirmed no deprecated `fitz` API references remain
  - Successfully built the source distribution and wheel using `uv build`
  - Reinstalled the editable tool
  - Confirmed `kokoro-tts --version` exits successfully without the warning